### PR TITLE
tasks/main.yml: "Enable/disable legacy networking" only after systemd network has been configured

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,13 +60,6 @@
     enabled: True
     state: started
 
-- name: Enable/disable legacy networking
-  service:
-    name: networking
-    enabled: "{{ systemd_network_enable_legacy_networking }}"
-    state: "{% if systemd_network_enable_legacy_networking %}started{% else %}stopped{% endif %}"
-  when: systemd_network_enable_legacy_networking != "keep"
-
 - meta: flush_handlers
 
 - name: Enable systemd-networkd service
@@ -74,3 +67,10 @@
     name: systemd-networkd
     enabled: True
     state: started
+
+- name: Enable/disable legacy networking
+  service:
+    name: networking
+    enabled: "{{ systemd_network_enable_legacy_networking }}"
+    state: "{% if systemd_network_enable_legacy_networking %}started{% else %}stopped{% endif %}"
+  when: systemd_network_enable_legacy_networking != "keep"


### PR DESCRIPTION
This makes it more likely that you don't lose access. Moreover it means
that if access is lost, then it is lost with the last task. I.e. after a
subsequent reboot everything is configured as desired.