### PR TITLE
Delete existing unwanted network interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,10 @@ systemd_network_networks:
 
 ## Role variable defaults
 
-| Name                                        | Default              | Description                                              |
-| :------------------------------------------ | :------------------- | :------------------------------------------------------- |
-| `systemd_network_netdevs`                   | `{}`                 | [#detailed-description](#detailed-description)           |
-| `systemd_network_networks`                  | `{}`                 | [#detailed-description](#detailed-description)           |
-| `systemd_network_copy_files`                | `[]`                 | [#upload-extra-files](#upload-extra-files)               |
-| `systemd_network_dns_resolver`              | `"systemd-resolved"` | [#dns-resolver](#dns-resolver)                           |
-| `systemd_network_keep_existing_definitions` | `false`              | Whether to keep existing files in `/etc/systemd/network` |
+| Name                                        | Default              | Description                                                                                                                                          |
+| :------------------------------------------ | :------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `systemd_network_netdevs`                   | `{}`                 | [#detailed-description](#detailed-description)                                                                                                       |
+| `systemd_network_networks`                  | `{}`                 | [#detailed-description](#detailed-description)                                                                                                       |
+| `systemd_network_copy_files`                | `[]`                 | [#upload-extra-files](#upload-extra-files)                                                                                                           |
+| `systemd_network_dns_resolver`              | `"systemd-resolved"` | [#dns-resolver](#dns-resolver)                                                                                                                       |
+| `systemd_network_keep_existing_definitions` | `false`              | If false, the role deletes existing `.netdev` and `.network` files in `/etc/systemd/network/` and also deletes the corresponding network interfaces. |

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,32 +6,26 @@
       - "*.netdev"
       - "*.network"
   register: systemd_network_existing_config_files
+  when: not systemd_network_keep_existing_definitions
 
 - name: Calculate which systemd-network config files to delete
   set_fact:
-    systemd_network_config_files_to_delete: >-
-      {{ systemd_network_existing_config_files.files
-          | map(attribute='path')
-          | difference(systemd_network_netdevs.keys()
-            | map('regex_replace', '^', '/etc/systemd/network/')
-            | map('regex_replace', '$', '.netdev')
-            | union(systemd_network_networks.keys()
-              | map('regex_replace', '^', '/etc/systemd/network/')
-              | map('regex_replace', '$', '.network')
-            )
-          )
+    systemd_network_netdevs_to_delete: >-
+      {{
+        systemd_network_existing_config_files.files
+        | map(attribute='path')
+        | select("match", ".*\.netdev$")
+        | map('basename') | map('splitext') | map('first')
+        | difference(systemd_network_netdevs.keys())
       }}
-
-- name: Delete existing unwanted systemd-networkd configs
-  file:
-    state: absent
-    path: "{{ config_file }}"
-  loop: "{{ systemd_network_config_files_to_delete }}"
-  loop_control:
-    loop_var: config_file
-  notify:
-    - Reload systemd configuration
-    - Restart systemd-networkd service
+    systemd_network_networks_to_delete: >-
+      {{
+        systemd_network_existing_config_files.files
+        | map(attribute='path')
+        | select("match", ".*\.network$")
+        | map('basename') | map('splitext') | map('first')
+        | difference(systemd_network_networks.keys())
+      }}
   when: not systemd_network_keep_existing_definitions
 
 - name: Instantiate systemd-networkd network devices
@@ -43,6 +37,7 @@
   loop: "{{ systemd_network_netdevs | dict2items }}"
   loop_control:
     loop_var: netdev
+    label: "{{ netdev.key }}"
   notify:
     - Reload systemd configuration
     - Restart systemd-networkd service
@@ -56,6 +51,7 @@
   loop: "{{ systemd_network_networks | dict2items }}"
   loop_control:
     loop_var: network
+    label: "{{ network.key }}"
   notify:
     - Reload systemd configuration
     - Restart systemd-networkd service
@@ -96,6 +92,42 @@
     name: "{{ systemd_network_dns_resolver }}"
     enabled: True
     state: started
+
+- name: Delete existing unwanted network interfaces
+  shell: |
+    if [ ! -e /sys/class/net/{{ interface_name | quote }} ]; then
+      exit 128
+    fi
+    ip link delete {{ interface_name | quote }}
+  # From `man ip`:
+  # Exit status is 0 if command was successful, and 1 if there is a syntax error.  If an error was reported by the kernel exit status is 2.
+  register: result
+  failed_when: result.rc not in [0, 128]
+  changed_when: result.rc != 128
+  notify:
+    - Restart systemd-networkd service
+  loop: "{{ systemd_network_netdevs_to_delete }}"
+  loop_control:
+    loop_var: interface_name
+  when: not systemd_network_keep_existing_definitions
+
+
+- name: Delete existing unwanted systemd-networkd configs
+  file:
+    state: absent
+    path: /etc/systemd/network/{{ basename }}
+  notify:
+    - Reload systemd configuration
+    - Restart systemd-networkd service
+  loop: >-
+    {{
+      systemd_network_netdevs_to_delete | map('regex_replace', '$', '.netdev')
+      +
+      systemd_network_networks_to_delete | map('regex_replace', '$', '.network')
+    }}
+  loop_control:
+    loop_var: basename
+  when: not systemd_network_keep_existing_definitions
 
 - meta: flush_handlers
 


### PR DESCRIPTION
Delete existing unwanted network interfaces but only if it was configured via systemd-networkd, i.e., only if the netdev config file is about to also be deleted.

Note that we delete the interface first and the netdev config file second. This is so that, in case deletion of the interface fails, a rerun of the role attempts to delete it again.