### PR TITLE
feat: Support list of dicts/lists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
         | map(attribute='path')
         | select("match", ".*\.netdev$")
         | map('basename') | map('splitext') | map('first')
-        | difference(systemd_network_netdevs.keys())
+        | difference((systemd_network_netdevs | combine).keys())
       }}
     systemd_network_networks_to_delete: >-
       {{
@@ -24,7 +24,7 @@
         | map(attribute='path')
         | select("match", ".*\.network$")
         | map('basename') | map('splitext') | map('first')
-        | difference(systemd_network_networks.keys())
+        | difference((systemd_network_networks | combine).keys())
       }}
   when: not systemd_network_keep_existing_definitions
 
@@ -34,7 +34,7 @@
     dest: /etc/systemd/network/{{ netdev.key }}.netdev
     owner: systemd-network
     mode: 0640
-  loop: "{{ systemd_network_netdevs | dict2items }}"
+  loop: "{{ systemd_network_netdevs | combine | dict2items }}"
   loop_control:
     loop_var: netdev
     label: "{{ netdev.key }}"
@@ -48,7 +48,7 @@
     dest: /etc/systemd/network/{{ network.key }}.network
     owner: systemd-network
     mode: 0640
-  loop: "{{ systemd_network_networks | dict2items }}"
+  loop: "{{ systemd_network_networks | combine | dict2items }}"
   loop_control:
     loop_var: network
     label: "{{ network.key }}"

--- a/templates/netdev.j2
+++ b/templates/netdev.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
 
 {% for section_name, section_contents in ({"NetDev": {"Name": netdev.key}} | combine(netdev.value, recursive=True)).items() %}
-{% for content in [section_contents] | flatten(levels=1) %}
+{% for content in [section_contents] | flatten %}
 [{{ section_name }}]
 {% for key, values in content.items() %}
-{% for v in [values] | flatten(levels=1) %}
+{% for v in [values] | flatten %}
 {{ key }}={{ v }}
 {% endfor %}
 {% endfor %}

--- a/templates/network.j2
+++ b/templates/network.j2
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
 
 {% for section_name, section_contents in ({"Match": {"Name": network.key}} | combine(network.value, recursive=False)).items() %}
-{% for content in [section_contents] | flatten(levels=1) %}
+{% for content in [section_contents] | flatten %}
 [{{ section_name }}]
 {% for key, values in content.items() %}
-{% for v in [values] | flatten(levels=1) %}
+{% for v in [values] | flatten %}
 {{ key }}={{ v }}
 {% endfor %}
 {% endfor %}


### PR DESCRIPTION
If a list of dicts (resp. lists) is given, we merge (resp. flatten) it. This enables some previously difficult ways to template and/or preprocess (using an external tool) the variables given to this role. Examples:

- Merging configurations from multiple sources where one (or multiple) of the sources is a Jinja2 template, e.g.,

  ```
  - eth0: ...
  ```

  merged with:

  ```
  - "{{ some_template_that_generates_multiple_netdevs_or_networks }}"
  ```
- Conditionally setting a key:

  ```
  - eth0:
      Network:
        Address:
          - 192.168.100.1/24
          - "{{ 'fe80::1/64' if enable_ipv6 else [] }}"
  ```