### PR TITLE
Adjustments for fresh debian/ubuntu installs

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,6 +7,7 @@
   service:
     name: systemd-networkd
     enabled: True
+    masked: False
     state: restarted
 
 - name: Restart systemd-resolved service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create extra directories relevant for systemd-networkd
+  file:
+    path: "{{ item | dirname }}"
+    state: directory
+  loop: "{{ systemd_network_copy_files | map(attribute='dest') | list + ['/etc/systemd/networkd.conf.d/', '/etc/systemd/resolved.conf.d/', '/etc/network/'] }}"
+
 - name: Find existing systemd-network config files
   find:
     paths:
@@ -38,12 +44,6 @@
         | difference((systemd_network_networks | combine).keys())
       }}
   when: not systemd_network_keep_existing_definitions
-
-- name: Create extra directories relevant for systemd-networkd
-  file:
-    path: "{{ item | dirname }}"
-    state: directory
-  loop: "{{ systemd_network_copy_files | map(attribute='dest') | list + ['/etc/systemd/networkd.conf.d/', '/etc/systemd/resolved.conf.d/'] }}"
 
 - name: Instantiate systemd-networkd networkd.conf drop-ins
   template:
@@ -199,11 +199,6 @@
     masked: True
     state: stopped
   when: networking_service_exists.rc == 0
-
-- name: Make sure /etc/network directory exists
-  file:
-    path: /etc/network
-    state: directory
 
 - name: Remove content from /etc/network/interfaces
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -107,8 +107,8 @@
     follow: False
 
 - name: Check if resolvconf service exists
-  command: systemctl list-unit-files resolvconf.service
-  failed_when: False
+  command: systemctl cat resolvconf.service
+  failed_when: resolvconf_service_list.rc not in [0, 1]
   changed_when: False
   register: resolvconf_service_list
 
@@ -187,10 +187,9 @@
 
 - name: Check if legacy networking exists
   command: systemctl cat networking
-  check_mode: no
-  register: networking_service_exists
-  changed_when: False
   failed_when: networking_service_exists.rc not in [0, 1]
+  changed_when: False
+  register: networking_service_exists
 
 - name: Disable legacy networking
   systemd:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -185,12 +185,25 @@
     enabled: True
     state: started
 
+- name: Check if legacy networking exists
+  command: systemctl cat networking
+  check_mode: no
+  register: networking_service_exists
+  changed_when: False
+  failed_when: networking_service_exists.rc not in [0, 1]
+
 - name: Disable legacy networking
   systemd:
     name: networking
     enabled: False
     masked: True
     state: stopped
+  when: networking_service_exists.rc == 0
+
+- name: Make sure /etc/network directory exists
+  file:
+    path: /etc/network
+    state: directory
 
 - name: Remove content from /etc/network/interfaces
   copy:


### PR DESCRIPTION
Thank you for this module.
When using this role on a freshly created Debian Bullseye lxc container, ansible prints error due to missing networking service and then warnings about missing /etc/network and /etc/systemd/networkd.conf.d folders.
This should fix both issues.
Also, systemd in Ubuntu (tested bionic and focal) has an issue with not honoring priority of config files from /etc over /run. Network config is then hardcoded to dhcp due to /run/systemd/network/10-netplan-enp1s0.network file taking precedence.
See https://askubuntu.com/questions/1391256/systemd-networking-basics-cannot-switch-from-dhcp-to-static-ip-address