### PR TITLE
feat(systemd-resolved): ensure package is installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -115,6 +115,11 @@
     state: stopped
   when: resolvconf_service_list.rc == 0
 
+- name: Install systemd-resolved
+  package:
+    name: systemd-resolved
+  when: ansible_distribution == 'Debian' and not ansible_distribution_major_version is version('12', '<')
+
 - name: Enable systemd-resolved
   service:
     name: systemd-resolved


### PR DESCRIPTION
As of Debian 12 systemd-resolved needs to be installed seperately.